### PR TITLE
B-RecurringTasks (first version)

### DIFF
--- a/data/duke.txt
+++ b/data/duke.txt
@@ -1,10 +1,10 @@
-D | 1 | ssss | 16/09/2019 0200
-D | 1 | tttt | 16/09/2019 0500
-E | 1 | tasktest | 16/09/2019 1000
-D | 1 | read book | 27/09/2019 1800
-D | 1 | watch movie | 27/09/2019 1800
-D | 1 | adding | 27/09/2019 1900
-D | 1 | hello | 27/09/2019 2000
-D | 1 | readbook | 27/09/2019 2300
-D | 0 | watch tv | 27/09/2019 1700
-D | 0 | hello | 27/09/2019 1800
+D | 1 | ssss | 16/09/2019 0200 | false
+D | 1 | tttt | 16/09/2019 0500 | false
+E | 1 | tasktest | 16/09/2019 1000 | false
+D | 1 | read book | 27/09/2019 1800 | false
+D | 1 | watch movie | 27/09/2019 1800 | false
+D | 1 | adding | 27/09/2019 1900 | false
+D | 1 | hello | 27/09/2019 2000 | false
+D | 1 | readbook | 27/09/2019 2300 | false
+D | 0 | watch tv | 27/09/2019 1700 | false
+D | 0 | hello | 27/09/2019 1800 | false

--- a/src/main/java/duke/command/RecurringCommand.java
+++ b/src/main/java/duke/command/RecurringCommand.java
@@ -1,0 +1,62 @@
+package duke.command;
+
+import duke.core.DukeException;
+import duke.core.Storage;
+import duke.core.TaskList;
+import duke.core.Ui;
+import duke.task.*;
+
+import java.time.LocalDateTime;
+
+public class RecurringCommand extends Command {
+
+    /**
+     * Used to identify the task being marked as recurring.
+     */
+    private int taskIndex;
+
+    public RecurringCommand(int taskIndex) {
+        super();
+        this.taskIndex = taskIndex;
+    }
+
+    /**
+     * Indicates whether Duke should exist
+     *
+     * @return A boolean. True if the command tells Duke to exit, false
+     * otherwise.
+     */
+    @Override
+    public boolean isExit() { return false; }
+
+    /**
+     * run the command with the respect TaskList, UI, and storage.
+     *
+     * Checks whether there is a DateTime for the listed task, and if so,
+     * marks it as 'recurring', calls the Ui to print a certain output, and informs
+     * storage that the task is now recurring.
+     *
+     * @param tasks   The task list where tasks are saved.
+     * @param ui      The user interface.
+     * @param storage object that handles local text file update
+     */
+    @Override
+    public void execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        try {
+            Task recurringTask = tasks.getTask(taskIndex);
+            if (recurringTask.getDateTime() != null) {
+                if (!recurringTask.isTaskRecurring()) {
+                    recurringTask.makeTaskRecurring();
+                    ui.makeRecurring(recurringTask);
+                }
+                recurringTask.recurringTaskTimeUpdate();
+                storage.save(tasks.fullTaskList());
+            } else {
+                recurringTask.updateLocalDateTime(LocalDateTime.now().toString());
+            }
+        } catch (DukeException e) {
+            throw new DukeException("I couldn't make the task recurring. " + e);
+        }
+
+    }
+}

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -85,6 +85,13 @@ public class Parser {
                 } catch (ParseException e) {
                     e.printStackTrace();
                 }
+            case "recurring":
+                try {
+                    int index = Integer.parseInt(command[1]);
+                    return new RecurringCommand(index);
+                } catch (Exception e) {
+                    throw new DukeException("Failed to make your task recurring." + e.getMessage());
+                }
             case "bye":
                 return new ExitCommand();
             default:

--- a/src/main/java/duke/core/Storage.java
+++ b/src/main/java/duke/core/Storage.java
@@ -50,6 +50,9 @@ public class Storage {
                     if (newTask[1].equals("1")) {
                         x.markAsDone();
                     }
+                    if (newTask[3].equals("true")) {
+                        x.makeTaskRecurring();
+                    }
                     tasks.add(x);
                 }
                 if (newTask[0].equals("D")) {
@@ -57,12 +60,18 @@ public class Storage {
                     if (newTask[1].equals("1")) {
                         t.markAsDone();
                     }
+                    if (newTask[4].equals("true")) {
+                        t.makeTaskRecurring();
+                    }
                     tasks.add(t);
                 }
                 if (newTask[0].equals("E")) {
                     Task t = new Event(newTask[2], newTask[3]);
                     if (newTask[1].equals("1")) {
                         t.markAsDone();
+                    }
+                    if (newTask[4].equals("true")) {
+                        t.makeTaskRecurring();
                     }
                     tasks.add(t);
                 }

--- a/src/main/java/duke/core/Ui.java
+++ b/src/main/java/duke/core/Ui.java
@@ -150,6 +150,13 @@ public class Ui {
 
         }
     }
+
+    public void makeRecurring(Task t) {
+        System.out.println("Okay. This task has been marked as recurring:\n"
+                            + t.toString());
+
+    }
+
     /**
      * Shows a divider line.
      */

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -45,7 +45,14 @@ public class Deadline extends Task {
      * @return A string in a specific format to be stored in a local file.
      */
     public String writeTxt() {
-        return "D | " + (this.isDone ? "1" : "0") + " | " + this.description + " | " + this.by;
+        return "D | "
+                + (this.isDone ? "1" : "0")
+                + " | "
+                + this.description
+                + " | "
+                + this.by
+                + " | "
+                + this.isRecurring;
     }
 
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -41,6 +41,13 @@ public class Event extends Task {
      * @return A string in a specific format to be stored in a local file.
      */
     public String writeTxt() {
-        return "E | " + (this.isDone ? "1" : "0") + " | " + this.description + " | " + this.at;
+        return "E | "
+                + (this.isDone ? "1" : "0")
+                + " | "
+                + this.description
+                + " | "
+                + this.at
+                + " | "
+                + this.isRecurring;
     }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -5,6 +5,7 @@ import duke.core.DukeException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -28,6 +29,10 @@ public abstract class Task {
      * a localDateTime constructor to save the date and time
      */
     protected LocalDateTime ld;
+    /**
+     * A boolean that represents whether or not a task is recurring. True = recurring, False = non-recurring
+     */
+    protected boolean isRecurring = false;
 
     /**
      * Initialises the minimum fields required to setup a Task.
@@ -69,6 +74,38 @@ public abstract class Task {
      */
     public void markAsDone() {
         isDone = true;
+    }
+
+    /**
+     * Marks the task as recurring.
+     */
+    public void makeTaskRecurring() { isRecurring = true; }
+
+    /**
+     * Returns boolean stating whether task is recurring.
+     */
+    public boolean isTaskRecurring() { return isRecurring; }
+
+    /**
+     * When a task is recurring, method compares current time to listed date.
+     * If the task's date is outdated, then it will update to be for the next day.
+     */
+    public void recurringTaskTimeUpdate() {
+        if ((ld != null) && this.isRecurring) {
+            try {
+                LocalDateTime currentTime = LocalDateTime.now();
+                if (this.ld.isBefore(currentTime)) {
+                    Duration dayDifference = Duration.between(currentTime, this.ld);
+                    if (Math.abs(dayDifference.toDays()) > 0 ) {
+                        this.ld = ld.plusDays(Math.abs(dayDifference.toDays()));
+
+                        if (!this.isDone) { this.isDone = false; }
+                    }
+                }
+            } catch (DateTimeParseException e) {
+                System.out.println("I couldn't update your recurring events' times.");
+            }
+        }
     }
 
     /**
@@ -132,6 +169,7 @@ public abstract class Task {
             System.out.println("Invalid format. Please Enter Date and Time in the format of dd/MM/yyyy HHmm");
         }
     }
+
     /**
      * Returns the data and time information stored in the task without a certain format.
      *
@@ -139,6 +177,7 @@ public abstract class Task {
      */
     public LocalDateTime getDateTime()
     {
+        if (this.isTaskRecurring()) { this.recurringTaskTimeUpdate(); }
         return ld;
     }
 

--- a/src/main/java/duke/task/Todo.java
+++ b/src/main/java/duke/task/Todo.java
@@ -32,7 +32,12 @@ public class Todo extends Task {
      * @return A string in a specific format to be stored in a local file.
      */
     public String writeTxt() {
-        return "T | " + (this.isDone() ? "1" : "0") + " | " + this.description;
+        return "T | "
+                + (this.isDone() ? "1" : "0")
+                + " | "
+                + this.description
+                + " | "
+                + this.isRecurring;
     }
 
 }


### PR DESCRIPTION
First version of B-Recurring types. 

User puts in a command formatted like: "recurring " + [index of task in list], and Duke will update the task's time so that it is the same as the current date, though the time (HHa) remains the same.

Does not accept dates without a valid DateTime yet--will add that soon.