### PR TITLE
Added Delete Patient Command by name or id. Added user confirmation before deleting a patient. 

### DIFF
--- a/src/main/java/duke/command/DeletePatientCommand.java
+++ b/src/main/java/duke/command/DeletePatientCommand.java
@@ -8,19 +8,49 @@ import duke.storage.PatientStorage;
 import duke.storage.TaskStorage;
 import duke.task.TaskList;
 
+import java.util.ArrayList;
+
 public class DeletePatientCommand extends Command {
     private int id;
+    private String command;
 
-    public DeletePatientCommand(int id) {
-        this.id = id;
+    public DeletePatientCommand(String command) {
+        this.command = command;
     }
 
     @Override
     public void execute(TaskList tasks, PatientList patientList, Ui ui, TaskStorage taskStorage, PatientStorage patientStorage) throws DukeException {
-        Patient patientToBeDeleted = patientList.getPatient(id);
-        patientList.deletePatient(id);
-        patientStorage.save(patientList.getPatientList());
-        ui.patientDeleted(patientToBeDeleted);
+        char firstChar = command.charAt(0);
+        if (firstChar == '#') {
+            int id;
+            try{
+                id = Integer.parseInt(command.substring(1, command.length()));
+            }catch(Exception e){
+                throw new DukeException("Please follow the format 'delete patient #<id>'.");
+            }
+
+            Patient patientToBeDeleted = patientList.getPatient(id);
+            boolean toDelete = ui.confirmPatientToBeDeleted(patientToBeDeleted);
+            if (toDelete){
+                patientList.deletePatient(id);
+                ui.patientDeleted();
+                patientStorage.save(patientList.getPatientList());
+            }
+        } else {
+            ArrayList<Patient> patientsWithSameName = patientList.getPatientByName(command);
+            ui.patientsFoundByName(patientsWithSameName, command);
+            if (patientsWithSameName.size() >= 1) {
+                int numberChosen = ui.choosePatientToDelete(patientsWithSameName.size());
+                if (numberChosen >= 1){
+                    boolean toDelete = ui.confirmPatientToBeDeleted(patientsWithSameName.get(numberChosen-1));
+                    if (toDelete){
+                        patientList.deletePatient(patientsWithSameName.get(numberChosen-1).getID());
+                        ui.patientDeleted();
+                        patientStorage.save(patientList.getPatientList());
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/java/duke/command/FindPatientCommand.java
+++ b/src/main/java/duke/command/FindPatientCommand.java
@@ -21,7 +21,12 @@ public class FindPatientCommand extends Command {
     public void execute(TaskList tasks, PatientList patientList, Ui ui, TaskStorage taskStorage, PatientStorage patientStorage) throws DukeException {
         char firstChar = command.charAt(0);
         if (firstChar == '#'){
-            int id = Integer.parseInt(command.substring(1, command.length()));
+            int id;
+            try {
+                id = Integer.parseInt(command.substring(1, command.length()));
+            }catch(Exception e) {
+                throw new DukeException("Please follow the format 'find patient #<id>' or 'find patient <name>'.");
+            }
             Patient patient = patientList.getPatient(id);
             ui.patientsFoundById(patient);
         }

--- a/src/main/java/duke/core/CommandManager.java
+++ b/src/main/java/duke/core/CommandManager.java
@@ -69,10 +69,9 @@ public class CommandManager {
                     String[] tempCommand = command[1].split("\\s+", 2);
                     if (tempCommand[0].toLowerCase().equals("patient")){
                         try {
-                            int id = Integer.parseInt(tempCommand[1]);
-                            return new DeletePatientCommand(id);
+                            return new DeletePatientCommand(tempCommand[1]);
                         }catch(Exception e){
-                            throw new Exception("Please follow the format 'delete patient <id>'.");
+                            throw new Exception("Please follow the format 'delete patient #<id>'.");
                         }
                     }
                     else {

--- a/src/main/java/duke/core/Ui.java
+++ b/src/main/java/duke/core/Ui.java
@@ -49,7 +49,7 @@ public class Ui {
     /**
      * Shows that a Task has been added
      *
-     * @param t    The Task that is added to the list.
+     * @param t The Task that is added to the list.
      */
     public void taskAdded(StandardTask standardTask) {
         System.out.println("Got it. I've added this task: \n" + standardTask);
@@ -62,17 +62,16 @@ public class Ui {
     }
 
     public void patientsFoundByName(ArrayList<Patient> patients, String name) {
-        if (patients.size() > 0){
-            System.out.println("Got it. "+ patients.size() +" patients is/are found with name: "+ name);
+        if (patients.size() > 0) {
+            System.out.println("Got it. " + patients.size() + " patients is/are found with name: " + name);
             int i = 1;
             for (Patient patient : patients) {
-                System.out.println("Patient #"+ i);
+                System.out.println("Patient #" + i);
                 showPatientInfo(patient);
                 showLine();
                 i++;
             }
-        }
-        else{
+        } else {
             System.out.println("No patient was found with name: " + name);
         }
     }
@@ -88,9 +87,47 @@ public class Ui {
         showPatientInfo(patient);
     }
 
-    public void patientDeleted(Patient patient) {
-        System.out.println("Got it. The following patient is deleted:  ");
+    public int choosePatientToDelete(int numberOfPatients) {
+        int chosenNumber = -1;
+        while (true) {
+            System.out.println("Enter the number of patient to delete, or enter number 0 to cancel: ");
+            String command = readCommand();
+            try {
+                chosenNumber = Integer.parseInt(command);
+            } catch (Exception e) {
+                System.out.println("Please enter a valid number!");
+                continue;
+            }
+            if (chosenNumber >= 0 && chosenNumber <= numberOfPatients) {
+                if (chosenNumber == 0) {
+                    System.out.println("Delete command is canceled");
+                }
+                return chosenNumber;
+            } else {
+                System.out.println("The patient #" + chosenNumber + " does not exist. Please enter a valid number!");
+            }
+        }
+
+    }
+
+    public boolean confirmPatientToBeDeleted(Patient patient) {
         showPatientInfo(patient);
+        while (true) {
+            System.out.println("The patient is to be deleted. Are you sure (Y/N)? ");
+            String command = readCommand();
+            if (command.toLowerCase().equals("y")) {
+                return true;
+            } else if (command.toLowerCase().equals("n")) {
+                System.out.println("Delete command is canceled");
+                return false;
+            } else {
+                System.out.println("Please enter only Y/N to confirm/cancel deletion!");
+            }
+        }
+    }
+
+    public void patientDeleted() {
+        System.out.println("Got it. The patient is deleted.");
     }
 
     public void listAllPatients(ArrayList<Patient> patients) {

--- a/src/main/java/duke/storage/PatientStorage.java
+++ b/src/main/java/duke/storage/PatientStorage.java
@@ -39,8 +39,7 @@ public class PatientStorage extends Storage<Patient> {
                 String nric = record.get("NRIC");
                 String remark = record.get("Remark");
                 String room = record.get("Room");
-                Patient patient = new Patient(id, name, nric, remark, room);
-                patientList.add(new Patient(id, name, nric, remark, room));
+                patientList.add(new Patient(id, name, nric, room, remark));
 //                System.out.println(id + " | " +  name + " | " + nric + " | " + remark + " | " + room); //List out patietns info for debugging
             }
             return patientList;


### PR DESCRIPTION
To delete patient **by name**: `delete patient <name>`
To delete patient **by id**: `delete patient #<id>`

When multiple patients with same name exist, all of then will be listed out. User can choose to delete one of them by entering the corresponding patient number. 

A final user confirmation is required before deletion by entering Y/N.

Example:
`delete patient #8`
```
____________________________________________________________
Name: weifeng  Id: 8
NRIC: G123123  Room: 2A
Remark: no
```
`The patient is to be deleted. Are you sure (Y/N)? `
`N`
```
Delete command is canceled
____________________________________________________________

```
`delete patient weifeng`
```
____________________________________________________________
Got it. 2 patients is/are found with name: weifeng
Patient #1
Name: weifeng  Id: 4
NRIC: asf  Room: ads
Remark: asd a
____________________________________________________________
Patient #2
Name: weifeng  Id: 5
NRIC: asf  Room: ads
Remark: asd
____________________________________________________________
Enter the number of patient to delete, or enter number 0 to cancel: 
```
`6`
```
The patient #6 does not exist. Please enter a valid number!
Enter the number of patient to delete, or enter number 0 to cancel: 
```
`2`
```
Name: weifeng  Id: 5
NRIC: asf  Room: ads
Remark: asd
The patient is to be deleted. Are you sure (Y/N)? 
```
`Y`
```
Got it. The patient is deleted.
____________________________________________________________
```

