### PR TITLE
Parser revisions made to aid DeleteAssignedTaskCommand

### DIFF
--- a/src/main/java/duke/core/CommandManager.java
+++ b/src/main/java/duke/core/CommandManager.java
@@ -63,7 +63,7 @@ public class CommandManager {
             return new DeleteTaskCommand(parser.parseDeleteTask());
         case "find patient":
             return new FindPatientCommand((parser.parseFindPatient()));
-        case "find assigned task":
+        case "find assigned tasks":
             return new FindPatientTaskCommand((parser.parseFindAssignedTasks()));
         case "update patient":
             return new UpdatePatientCommand(parser.parseUpdatePatient());

--- a/src/main/java/duke/core/CommandManager.java
+++ b/src/main/java/duke/core/CommandManager.java
@@ -63,8 +63,8 @@ public class CommandManager {
             return new DeleteTaskCommand(parser.parseDeleteTask());
         case "find patient":
             return new FindPatientCommand((parser.parseFindPatient()));
-        case "find assigned tasks":
-            return new FindPatientTaskCommand((parser.parseFindAssignedTasks()));
+        case "find assigned task":
+            return new FindPatientTaskCommand((parser.parseFindAssignedTask()));
         case "update patient":
             return new UpdatePatientCommand(parser.parseUpdatePatient());
         case "update task":

--- a/src/main/java/duke/core/CommandManager.java
+++ b/src/main/java/duke/core/CommandManager.java
@@ -64,7 +64,7 @@ public class CommandManager {
         case "find patient":
             return new FindPatientCommand((parser.parseFindPatient()));
         case "find assigned task":
-            return new FindPatientTaskCommand((parser.parseFindAssignedTask()));
+            return new FindPatientTaskCommand((parser.parseFindAssignedTasks()));
         case "update patient":
             return new UpdatePatientCommand(parser.parseUpdatePatient());
         case "update task":

--- a/src/main/java/duke/core/CommandManager.java
+++ b/src/main/java/duke/core/CommandManager.java
@@ -63,8 +63,8 @@ public class CommandManager {
             return new DeleteTaskCommand(parser.parseDeleteTask());
         case "find patient":
             return new FindPatientCommand((parser.parseFindPatient()));
-        case "find patient tasks":
-            return new FindPatientTaskCommand((parser.parseFindPatientTasks()));
+        case "find assigned tasks":
+            return new FindPatientTaskCommand((parser.parseFindAssignedTasks()));
         case "update patient":
             return new UpdatePatientCommand(parser.parseUpdatePatient());
         case "update task":

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -234,7 +234,7 @@ public class Parser {
      * @return A string of formatted output to be used by 'find patient task' command.
      * @throws DukeException Thrown when the user input cannot be parsed in the desired manner.
      */
-    public String parseFindAssignedTasks() throws DukeException {
+    public String parseFindAssignedTask() throws DukeException {
         try {
             String formattedInput = parsedInput[1].trim();
             return formattedInput;

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -234,12 +234,12 @@ public class Parser {
      * @return A string of formatted output to be used by 'find patient task' command.
      * @throws DukeException Thrown when the user input cannot be parsed in the desired manner.
      */
-    public String parseFindPatientTasks() throws DukeException {
+    public String parseFindAssignedTasks() throws DukeException {
         try {
             String formattedInput = parsedInput[1].trim();
             return formattedInput;
         } catch (Exception e) {
-            throw new DukeException("Please use the `find patient tasks :<patient name> or #<patient id>` format.");
+            throw new DukeException("Please use the `find assigned tasks :<patient name> or #<patient id>` format.");
         }
     }
 }

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -143,11 +143,11 @@ public class Parser {
     }
 
     /**
-     * Takes user input and formats it so it is compatible with 'delete patient task' command.
-     * `delete patient task` output: patient_name or #patient_id, task_name or #task_id
-     * `delete patient task` output: assigned_task_unique_id
+     * Takes user input and formats it so it is compatible with 'delete assigned task' command.
+     * `delete assigned task` output: patient_name or #patient_id, task_name or #task_id
+     * `delete assigned task` output: assigned_task_unique_id
      *
-     * @return Array of strings to be used by 'delete patient task' command.
+     * @return Array of strings to be used by 'delete assigned task' command.
      * @throws DukeException when user input cannot be parsed properly.
      */
     public String[] parseDeleteAssignedTask() throws DukeException {
@@ -164,7 +164,7 @@ public class Parser {
                 return formattedInput;
             }
         } catch (Exception e) {
-            throw new DukeException("Please follow the `delete patient task :<patient name> or #<patient id>"
+            throw new DukeException("Please follow the `delete assigned task :<patient name> or #<patient id>"
                     + " :<task name> or #<task id>` or "
                     + " `delete patient task :%<unique assigned task id>` format.");
         }
@@ -187,7 +187,7 @@ public class Parser {
             return formattedInput;
         } catch (Exception e) {
             throw new DukeException("Please use the `update patient :<patient name> or #<patient id>"
-                    + "/<edited info type> :<updated info>` format.");
+                    + ":<edited info type> :<updated info>` format.");
         }
     }
 
@@ -206,7 +206,7 @@ public class Parser {
             }
             return formattedInput;
         } catch (Exception e) {
-            throw new DukeException("Please use the `update patient :<task name> or #<task id>"
+            throw new DukeException("Please use the `update task :<task name> or #<task id>"
                     + " :<updated description>` format.");
         }
     }
@@ -228,18 +228,18 @@ public class Parser {
     }
 
     /**
-     * Takes the user input and formats it so it is compatible with 'find patient task' command.
-     * `find patient tasks` output: patient_name or #patient_id
+     * Takes the user input and formats it so it is compatible with 'find assigned tasks' command.
+     * `find assigned tasks` output: patient_name or #patient_id
      *
-     * @return A string of formatted output to be used by 'find patient task' command.
+     * @return A string of formatted output to be used by 'find assigned tasks' command.
      * @throws DukeException Thrown when the user input cannot be parsed in the desired manner.
      */
-    public String parseFindAssignedTask() throws DukeException {
+    public String parseFindAssignedTasks() throws DukeException {
         try {
             String formattedInput = parsedInput[1].trim();
             return formattedInput;
         } catch (Exception e) {
-            throw new DukeException("Please use the `find assigned task :<patient name> or #<patient id>` format.");
+            throw new DukeException("Please use the `find assigned tasks :<patient name> or #<patient id>` format.");
         }
     }
 }

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -239,7 +239,7 @@ public class Parser {
             String formattedInput = parsedInput[1].trim();
             return formattedInput;
         } catch (Exception e) {
-            throw new DukeException("Please use the `find assigned tasks :<patient name> or #<patient id>` format.");
+            throw new DukeException("Please use the `find assigned task :<patient name> or #<patient id>` format.");
         }
     }
 }

--- a/src/main/java/duke/core/Parser.java
+++ b/src/main/java/duke/core/Parser.java
@@ -145,6 +145,7 @@ public class Parser {
     /**
      * Takes user input and formats it so it is compatible with 'delete patient task' command.
      * `delete patient task` output: patient_name or #patient_id, task_name or #task_id
+     * `delete patient task` output: assigned_task_unique_id
      *
      * @return Array of strings to be used by 'delete patient task' command.
      * @throws DukeException when user input cannot be parsed properly.
@@ -152,13 +153,20 @@ public class Parser {
     public String[] parseDeleteAssignedTask() throws DukeException {
         try {
             String[] formattedInput = new String[2];
-            for (int i = 1; i <= formattedInput.length; i++) {
-                formattedInput[i - 1] = parsedInput[i].trim();
+
+            if (parsedInput[1].trim().charAt(0) == '%') {
+                formattedInput[0] = parsedInput[1];
+                return formattedInput;
+            } else {
+                for (int i = 1; i <= formattedInput.length; i++) {
+                    formattedInput[i - 1] = parsedInput[i].trim();
+                }
+                return formattedInput;
             }
-            return formattedInput;
         } catch (Exception e) {
             throw new DukeException("Please follow the `delete patient task :<patient name> or #<patient id>"
-                    + " :<task name> or #<task id>` format.");
+                    + " :<task name> or #<task id>` or "
+                    + " `delete patient task :%<unique assigned task id>` format.");
         }
     }
 

--- a/src/test/java/duke/core/ParserTest.java
+++ b/src/test/java/duke/core/ParserTest.java
@@ -20,6 +20,7 @@ public class ParserTest {
     String deleteTaskInputWithName = "delete task :Take medicine";
     String deleteAssignedTaskInputWithID = "delete assigned task :#2 :#5";
     String deleteAssignedTaskInputWithName = "delete assigned task :patient name :task name";
+    String deleteAssignedTaskInputWithUniqueID = "delete assigned task :%3";
 
     @Test
     public void parseAddPatientTest() throws DukeException {
@@ -98,13 +99,8 @@ public class ParserTest {
     @Test
     public void parseDeleteAssignedTask() throws DukeException {
         Parser testParserID = new Parser(deleteAssignedTaskInputWithID);
-        Parser testParserName = new Parser(deleteAssignedTaskInputWithName);
-
         String[] testOutputID = testParserID.parseDeleteAssignedTask();
-        String[] testOutputName = testParserName.parseDeleteAssignedTask();
-
         String[] desiredOutputID = {"#2", "#5"};
-        String[] desiredOutputName = {"patient name", "task name"};
 
         assertTrue(desiredOutputID.length == testOutputID.length);
         for (int i = 0; i < desiredOutputID.length; i++) {
@@ -112,11 +108,20 @@ public class ParserTest {
                     + desiredOutputID[i] + " but got: " + testOutputID[i]);
         }
 
+        Parser testParserName = new Parser(deleteAssignedTaskInputWithName);
+        String[] testOutputName = testParserName.parseDeleteAssignedTask();
+        String[] desiredOutputName = {"patient name", "task name"};
         assertTrue(desiredOutputName.length == testOutputName.length);
         for (int i = 0; i < desiredOutputName.length; i++) {
             assertTrue(desiredOutputName[i].equals(testOutputName[i]), "Parsing failed. Expected: "
                     + desiredOutputName[i] + " but got: " + testOutputName[i]);
         }
+
+        Parser testParserUniqueID = new Parser(deleteAssignedTaskInputWithUniqueID);
+        String[] testOutputUniqueID = testParserUniqueID.parseDeleteAssignedTask();
+        String[] desiredOutputUniqueID = {"%3"};
+        assertTrue(desiredOutputUniqueID[0].equals(testOutputUniqueID[0]), "Parsing failed. Expected: "
+                + desiredOutputUniqueID[0] + " but got: " + testOutputUniqueID[0]);
 
     }
 


### PR DESCRIPTION
Should prevent null exception in instances where user uses unique ID.

EDIT: changed `patient task`-related commands to `assigned task`-related commands in order to keep consistent with other referrals to methods relevant to the PatientTask class; can revert changes if this change is not agreeable.