### PR TITLE
Prompts user if the task is assigned to any patients and alerts user that the deletion will cause the task no longer assigned to these patients.

### DIFF
--- a/src/main/java/duke/command/DeleteTaskCommand.java
+++ b/src/main/java/duke/command/DeleteTaskCommand.java
@@ -1,8 +1,12 @@
+//@@author kkeejjuunn
+
 package duke.command;
 
 import duke.core.DukeException;
 import duke.core.Ui;
+import duke.patient.Patient;
 import duke.patient.PatientManager;
+import duke.relation.PatientTask;
 import duke.relation.PatientTaskList;
 import duke.storage.StorageManager;
 import duke.task.Task;
@@ -11,68 +15,112 @@ import duke.task.TaskManager;
 import java.util.ArrayList;
 
 public class DeleteTaskCommand extends Command {
-    private int id;
     private String deletedTaskInfo;
+    private Task taskToBeDeleted;
 
     /**
-     * .
+     * It keeps the delete task command.
      *
-     * @param deletedTaskInfo .
-     * @throws DukeException .
+     * @param deletedTaskInfo contains the information of the patient to be deleted.
      */
-    public DeleteTaskCommand(String deletedTaskInfo) throws DukeException {
-
+    public DeleteTaskCommand(String deletedTaskInfo) {
         this.deletedTaskInfo = deletedTaskInfo;
-        char firstChar = deletedTaskInfo.charAt(0);
-        if (firstChar == '#') {
-            try {
-                this.id = Integer.parseInt(deletedTaskInfo.substring(1));
-            } catch (Exception e) {
-                throw new DukeException("Please follow format 'delete task #<id>'. ");
-            }
-        }
     }
 
     /**
-     * .
+     * It extracts the task id from the delete task command.
+     * It checks whether user is trying to delete a task by id or description.
+     * It retrieves task based on the id extracted.
      *
-     * @param patientTask        .
-     * @param taskManager        .
-     * @param patientManager     .
-     * @param ui                 .
-     * @param storageManager .
-     * @throws DukeException .
+     * @param deletedTaskInfo contains the delete command received from parser class which is a string.
+     * @param ui allow user choose the correct task to be deleted.
+     * @param taskManager retrieves the task to be deleted.
+     * @return the task to be deleted.
+     * @throws DukeException if no match task found.
      */
-    @Override
-    public void execute(PatientTaskList patientTask, TaskManager taskManager, PatientManager patientManager,
-                        Ui ui, StorageManager storageManager) throws DukeException {
-        if (id != 0) {
-            Task taskToBeDeleted = taskManager.getTask(id);
-            boolean toDelete = ui.confirmTaskToBeDeleted(taskToBeDeleted);
-            if (toDelete) {
-                taskManager.deleteTask(id);
-                ui.taskDeleted();
-                storageManager.saveTasks(taskManager.getTaskList());
+    public Task getTaskByDeleteTaskCommand(String deletedTaskInfo, Ui ui,
+                                           TaskManager taskManager) throws DukeException {
+        char firstChar = deletedTaskInfo.charAt(0);
+        Task task = null;
+        if (firstChar == '#') {
+            int id;
+            try {
+                id = Integer.parseInt(deletedTaskInfo.substring(1));
+            } catch (Exception e) {
+                throw e;
+            }
+            try {
+                task = taskManager.getTask(id);
+            } catch (Exception e) {
+                throw new DukeException("The task id does not exist. ");
             }
         } else {
             ArrayList<Task> tasksWithSameDescription = taskManager.getTaskByDescription(deletedTaskInfo);
-            ui.tasksFoundByDescription(tasksWithSameDescription, deletedTaskInfo);
             if (tasksWithSameDescription.size() >= 1) {
                 int numberChosen = ui.chooseTaskToDelete(tasksWithSameDescription.size());
                 if (numberChosen >= 1) {
-                    boolean toDelete = ui.confirmTaskToBeDeleted(tasksWithSameDescription.get(numberChosen - 1));
-                    if (toDelete) {
-                        taskManager.deleteTask(tasksWithSameDescription.get(numberChosen - 1).getID());
-                        ui.taskDeleted();
-                        storageManager.saveTasks(taskManager.getTaskList());
-                    }
+                    task = tasksWithSameDescription.get(numberChosen - 1);
                 }
+            } else {
+                throw new DukeException("There is no task matched this description. ");
             }
+        }
+        return task;
+    }
+
+    /**
+     * It deletes the task returned from getTaskByDeleteTaskCommand.
+     * It checks whether this task is assigned to any patient.
+     * It deletes the relation between this task and any patients
+     *
+     * @param patientTaskList contains the information between all the tasks and patients.
+     * @param taskManager contains information of all tasks.
+     * @param patientManager contains information of all patients.
+     * @param ui interacts with user.
+     * @param storageManager save the changes in csv file.
+     * @throws DukeException if there is error deleting the task.
+     */
+    @Override
+    public void execute(PatientTaskList patientTaskList, TaskManager taskManager, PatientManager patientManager,
+                        Ui ui, StorageManager storageManager) throws DukeException {
+        try {
+            taskToBeDeleted = getTaskByDeleteTaskCommand(deletedTaskInfo, ui, taskManager);
+        } catch (Exception e) {
+            throw e;
+        }
+        ui.showTaskInfo(taskToBeDeleted);
+        boolean toDelete;
+        try {
+            ArrayList<PatientTask> patientTasks = patientTaskList.getTaskPatient(taskToBeDeleted.getID());
+            ArrayList<Patient> relatedPatients = new ArrayList<>();
+            for (PatientTask patientTask : patientTasks) {
+                relatedPatients.add(patientManager.getPatient(patientTask.getPatientId()));
+            }
+            ui.taskPatientFound(taskToBeDeleted, patientTasks, relatedPatients);
+            toDelete = ui.confirmTaskToBeDeleted(taskToBeDeleted, true);
+            if (toDelete) {
+                patientTaskList.deleteAllPatientTaskByTaskId(taskToBeDeleted.getID());
+                storageManager.saveAssignedTasks(patientTaskList.fullPatientTaskList());
+            }
+        } catch (Exception e) {
+            toDelete = ui.confirmTaskToBeDeleted(taskToBeDeleted,false);
+        }
+        if (toDelete) {
+            taskManager.deleteTask(taskToBeDeleted.getID());
+            storageManager.saveTasks(taskManager.getTaskList());
+            ui.taskDeleted();
         }
     }
 
+    /**
+     * It terminates the Dukepital.
+     *
+     * @return false.
+     */
     @Override
     public boolean isExit() {
         return false;
     }
 }
+
+

--- a/src/main/java/duke/core/Ui.java
+++ b/src/main/java/duke/core/Ui.java
@@ -206,16 +206,17 @@ public class Ui {
         }
     }
 
+    //@@author kkeejjuunn
     /**
      * It asks user to choose a task to be deleted from a list of tasks.
      *
      * @param numberOfTasks the number of task contain in the list
-     * @return the number being choosen by user. If return -1, it means user canceled the deletion
+     * @return the index being chosen by user. If return -1, it means user canceled the deletion
      */
     public int chooseTaskToDelete(int numberOfTasks) {
         int chosenNumber = -1;
         while (true) {
-            System.out.println("Enter the number of task to delete, or enter number 0 to cancel: ");
+            System.out.println("Enter the index of task to delete, or enter number 0 to cancel: ");
             String command = readCommand();
             try {
                 chosenNumber = Integer.parseInt(command);
@@ -232,8 +233,8 @@ public class Ui {
                 System.out.println("The task #" + chosenNumber + " does not exist. Please enter a valid number!");
             }
         }
-
     }
+
 
     /**
      * It confirms with user on the deletion of a patient.
@@ -270,12 +271,14 @@ public class Ui {
         System.out.println("Got it. The patient is deleted.");
     }
 
+    //@@author kkeejjuunn
     /**
-     * It shows message of a task being deleted.
+     * It shows message of a task being deleted successfully.
      */
     public void taskDeleted() {
         System.out.println("Got it. The task is deleted.");
     }
+
 
     /**
      * It lists out all info of patients.
@@ -329,17 +332,25 @@ public class Ui {
         }
     }
 
+    //@@author kkeejjuunn
     /**
      * It confirms with user on the deletion of a task.
+     * It alerts user that the deletion will cause the current patient who assigned
+     * to this task will no longer assigned to this task.
      * If user confirms, key in 'Y'. Otherwise key in 'N'.
      *
-     * @param task it contains task's info
+     * @param task contains task's info
+     * @param assignedToAnyPatient indicates whether the task is assigned to any patient
      * @return true if user confirmed the deletion. False otherwise.
      */
-    public boolean confirmTaskToBeDeleted(Task task) {
-        showTaskInfo(task);
+    public boolean confirmTaskToBeDeleted(Task task, boolean assignedToAnyPatient) {
         while (true) {
-            System.out.println("The task is to be deleted. Are you sure (Y/N)? ");
+            if (assignedToAnyPatient) {
+                System.out.println("The task is to be deleted. These patients will no "
+                        + "longer assigned to this task. Are you sure (Y/N)?");
+            } else {
+                System.out.println("The task is to be deleted. Are you sure (Y/N)? ");
+            }
             String command = readCommand();
             if (command.toLowerCase().equals("y")) {
                 return true;
@@ -351,6 +362,7 @@ public class Ui {
             }
         }
     }
+
 
     /**
      * It confirms with user on the deletion of a task.
@@ -444,6 +456,26 @@ public class Ui {
             showLine();
         }
     }
+
+    //@@author kkeejjuunn
+    /**
+     * It shows all info of patientTasks found which are associated with the task given by user.
+     *
+     * @param task     task given by user
+     * @param patientTask list of patienttasks being found associated with the task
+     * @param patients       list of patients relate to task
+     */
+    public void taskPatientFound(Task task, ArrayList<PatientTask> patientTask, ArrayList<Patient> patients) {
+        System.out.println("The task " + task.getID() + " " + task.getDescription()
+                + " assigned to following patient(s) is/are found : \n");
+        for (int i = 0; i < patientTask.size(); i++) {
+            showLine();
+            System.out.println(patients.get(i).getID() + ". " + patients.get(i).getName() + "\n");
+            System.out.println(patientTask.get(i).toString());
+            showLine();
+        }
+    }
+
     //@@author qjie7
     /**
      * Provide the necessary task details from the user for short cut feature.


### PR DESCRIPTION
When user is trying to delete a task by id or description, the system will check if the task is assigned to any patient. There will be a double confirmation in case that user accidentally delete a task that is still in use. Related to issue #160

If there are tasks assigned to this patient, all these tasks will be show so the user can check whether these tasks have been performed.