### PR TITLE
Added Statistic Tab and various Shortcuts in GUI

### DIFF
--- a/src/main/java/duke/Duke.java
+++ b/src/main/java/duke/Duke.java
@@ -106,9 +106,20 @@ public class Duke {
      *
      * @return .
      */
-    public AssignedTaskManager getAssignedTaskManager() {
+    public StorageManager getStorageManager() {
+        return storageManager;
+    }
+
+    /**
+     * .
+     *
+     * @return .
+     */
+    public  AssignedTaskManager getAssignedTaskManager() {
         return assignedTaskManager;
     }
+
+
 
 
     /**

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -11,23 +11,30 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
-import javafx.scene.Parent;
+import javafx.scene.Group;
 import javafx.scene.Scene;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.PieChart;
-import javafx.scene.control.*;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Button;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 
@@ -41,18 +48,6 @@ public class MainWindow extends AnchorPane {
     private VBox dialogContainer;
     @FXML
     private TextField userInput;
-    @FXML
-    private Button sendButton;
-    @FXML
-    private Button addPatientButton;
-    @FXML
-    private Button deletePatientButton;
-    @FXML
-    private Button updatePatientButton;
-    @FXML
-    private Button listPatientsButton;
-    @FXML
-    private Button listTasksButton;
     @FXML
     private TableView<Patient> patientTable;
     @FXML
@@ -131,64 +126,17 @@ public class MainWindow extends AnchorPane {
     private DatePicker assignTaskStartDatePicker;
     @FXML
     private DatePicker assignTaskEndDatePicker;
-    @FXML
-    private PieChart pieChart;
-
 
     private final Duke duke = new Duke("./data");
-//    public void initializePieChartViews() throws DukeException {
-//
-//         //PieChart pieChart = new PieChart();
-//        Map<String, Integer> counterMap = new HashMap<>();
-//        counterMap = duke.getStorageManager().loadCommandFrequency();
-//        ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
-//        ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
-//
-//        ObservableList<javafx.scene.chart.PieChart.Data> list = FXCollections.observableArrayList(
-//
-//                new javafx.scene.chart.PieChart.Data(commandNameList.get(0) , frequencyList.get(0)),
-//                new javafx.scene.chart.PieChart.Data(commandNameList.get(1) , frequencyList.get(1))
-//        );
-//        pieChart.setData(list);
-//
-//    }
-
-    public void handlePieChartButton() throws DukeException, IOException {
-        Map<String, Integer> counterMap = new HashMap<>();
-        counterMap = duke.getStorageManager().loadCommandFrequency();
-        ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
-        ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
-        ObservableList<javafx.scene.chart.PieChart.Data> list = FXCollections.observableArrayList(
-
-                new PieChart.Data(commandNameList.get(0) , frequencyList.get(0)),
-                new PieChart.Data(commandNameList.get(1) , frequencyList.get(1))
-//                new PieChart.Data(commandNameList.get(2) , frequencyList.get(2))
-//                new PieChart.Data(commandNameList.get(3) , frequencyList.get(3)),
-//                new PieChart.Data(commandNameList.get(4) , frequencyList.get(4)),
-//                new PieChart.Data(commandNameList.get(5) , frequencyList.get(5)),
-//                new PieChart.Data(commandNameList.get(6) , frequencyList.get(6)),
-//                new PieChart.Data(commandNameList.get(7) , frequencyList.get(7)),
-//                new PieChart.Data(commandNameList.get(8) , frequencyList.get(8))
-//                new PieChart.Data(commandNameList.get(9) , frequencyList.get(9)),
-//                new PieChart.Data(commandNameList.get(10) , frequencyList.get(10)),
-//                new PieChart.Data(commandNameList.get(11) , frequencyList.get(11)),
-//                new PieChart.Data(commandNameList.get(12) , frequencyList.get(12))
-
-        );
-        pieChart.setData(list);
-    }
-
-
-
 
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
     private Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/robot.png"));
 
     private ObservableList<AssignedTask> assignedTaskData = FXCollections
-        .observableArrayList(duke.getAssignedTaskManager().getAssignTasks());
+            .observableArrayList(duke.getAssignedTaskManager().getAssignTasks());
     private ObservableList<Task> taskData = FXCollections.observableArrayList(duke.getTaskManager().getTaskList());
     private ObservableList<Patient> patientData = FXCollections
-        .observableArrayList(duke.getPatientManager().getPatientList());
+            .observableArrayList(duke.getPatientManager().getPatientList());
 
     /**
      * .
@@ -208,6 +156,84 @@ public class MainWindow extends AnchorPane {
         executeDukeWithInput(userInput.getText());
         userInput.clear();
     }
+
+    //@@author qjie7
+
+    /**
+     * Event handler of PieChartPopUpButton.
+     */
+    public void handlePieChartPopUpButton() throws DukeException {
+        Map<String, Integer> counterMap = new HashMap<>();
+        counterMap = duke.getStorageManager().loadCommandFrequency();
+        ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
+        ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
+        final Scene scene = new Scene(new Group());
+        Stage stage = new Stage();
+        stage.setTitle("Pie Chart");
+
+        stage.setWidth(500);
+        stage.setHeight(500);
+
+        ObservableList<PieChart.Data> pieChartData =
+                FXCollections.observableArrayList(
+                    new PieChart.Data(commandNameList.get(0), frequencyList.get(0)),
+                    new PieChart.Data(commandNameList.get(1), frequencyList.get(1)),
+                    new PieChart.Data(commandNameList.get(2), frequencyList.get(2)),
+                    new PieChart.Data(commandNameList.get(3), frequencyList.get(3)),
+                    new PieChart.Data(commandNameList.get(4), frequencyList.get(4)),
+                    new PieChart.Data(commandNameList.get(5), frequencyList.get(5)),
+                    new PieChart.Data(commandNameList.get(6), frequencyList.get(6)),
+                    new PieChart.Data(commandNameList.get(7), frequencyList.get(7)),
+                    new PieChart.Data(commandNameList.get(8), frequencyList.get(8))
+                );
+        final PieChart chart = new PieChart(pieChartData);
+        chart.setTitle("Command Frequency");
+
+        ((Group) scene.getRoot()).getChildren().add(chart);
+        stage.setScene(scene);
+        stage.show();
+
+    }
+
+    /**
+     * Event handler of BarCharPopUpButton.
+     */
+    public void handleBarChartPopUpButton() throws DukeException {
+        Map<String, Integer> counterMap;
+        counterMap = duke.getStorageManager().loadCommandFrequency();
+        final ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
+        final ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
+        int year = Calendar.getInstance().get(Calendar.YEAR);
+        final String yearInString = Integer.toString(year);
+        Stage stage = new Stage();
+        stage.setTitle("Bar Chart");
+        final CategoryAxis xAxis = new CategoryAxis();
+        final NumberAxis yAxis = new NumberAxis();
+        final BarChart<String, Number> bc = new BarChart<String, Number>(xAxis, yAxis);
+        bc.setTitle("Command Frequency");
+        xAxis.setLabel("Command");
+        yAxis.setLabel("Frequency");
+
+        XYChart.Series series1 = new XYChart.Series();
+
+        series1.setName(yearInString);
+        series1.getData().add(new XYChart.Data(commandNameList.get(0), frequencyList.get(0)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(1), frequencyList.get(1)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(2), frequencyList.get(2)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(3), frequencyList.get(3)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(4), frequencyList.get(4)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(5), frequencyList.get(5)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(6), frequencyList.get(6)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(7), frequencyList.get(7)));
+        series1.getData().add(new XYChart.Data(commandNameList.get(8), frequencyList.get(8)));
+
+        Scene scene = new Scene(bc, 800, 600);
+        bc.getData().addAll(series1);
+        stage.setScene(scene);
+        stage.show();
+
+    }
+
 
     /**
      * Action takes to after add patient button is being pressed.
@@ -276,8 +302,8 @@ public class MainWindow extends AnchorPane {
      */
     @FXML
     private void handleDeleteTaskButton() {
-        String Id = deleteTaskIdField.getText();
-        String input = "delete task:" + "#" + Id;
+        String id = deleteTaskIdField.getText();
+        String input = "delete task:" + "#" + id;
         executeDukeWithInput(input);
         deleteTaskIdField.clear();
     }
@@ -304,15 +330,15 @@ public class MainWindow extends AnchorPane {
         String startTime = assignTaskStartTimeField.getText();
         String endTime = assignTaskEndTimeField.getText();
         String input = "assign period task :" + "#" + patientId + " :"
-                        + "#" + taskId + " :" + startDateInString + " " + startTime
-                        + " :" + endDateInString + " " + endTime;
+                + "#" + taskId + " :" + startDateInString + " " + startTime
+                + " :" + endDateInString + " " + endTime;
         executeDukeWithInput(input);
         assignTaskIdField.clear();
         assignTaskPatientIdField.clear();
         assignTaskStartTimeField.clear();
         assignTaskEndTimeField.clear();
     }
-
+    //@@author
 
 
     /**
@@ -330,8 +356,8 @@ public class MainWindow extends AnchorPane {
         }
         updateTableViews();
         dialogContainer.getChildren().addAll(
-            DialogBox.getUserDialog(inputCommand, userImage),
-            DialogBox.getDukeDialog(dukeResponses, dukeImage, isException)
+                DialogBox.getUserDialog(inputCommand, userImage),
+                DialogBox.getDukeDialog(dukeResponses, dukeImage, isException)
         );
         duke.clearDukeResponses();
     }
@@ -483,10 +509,10 @@ public class MainWindow extends AnchorPane {
                     if (assignedTask.getType().toLowerCase().contains(lowerCaseFilter)) {
                         return true;
                     } else if (duke.getTaskManager().getTask((assignedTask.getTid()))
-                        .getDescription().toLowerCase().contains(lowerCaseFilter)) {
+                            .getDescription().toLowerCase().contains(lowerCaseFilter)) {
                         return true;
                     } else if (duke.getPatientManager().getPatient((assignedTask.getPid()))
-                        .getName().toLowerCase().contains(lowerCaseFilter)) {
+                            .getName().toLowerCase().contains(lowerCaseFilter)) {
                         return true;
                     } else if (String.valueOf(assignedTask.getUuid()).contains(lowerCaseFilter)) {
                         return true;

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -11,15 +11,24 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
-import javafx.scene.control.TextField;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.chart.PieChart;
+import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.image.Image;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -42,6 +51,8 @@ public class MainWindow extends AnchorPane {
     private Button updatePatientButton;
     @FXML
     private Button listPatientsButton;
+    @FXML
+    private Button listTasksButton;
     @FXML
     private TableView<Patient> patientTable;
     @FXML
@@ -104,8 +115,71 @@ public class MainWindow extends AnchorPane {
     private TextField updatePatientColumnField;
     @FXML
     private TextField updatePatientContentField;
+    @FXML
+    private TextField addTaskNameField;
+    @FXML
+    private TextField deleteTaskIdField;
+    @FXML
+    private TextField assignTaskIdField;
+    @FXML
+    private TextField assignTaskPatientIdField;
+    @FXML
+    private TextField assignTaskStartTimeField;
+    @FXML
+    private TextField assignTaskEndTimeField;
+    @FXML
+    private DatePicker assignTaskStartDatePicker;
+    @FXML
+    private DatePicker assignTaskEndDatePicker;
+    @FXML
+    private PieChart pieChart;
+
 
     private final Duke duke = new Duke("./data");
+//    public void initializePieChartViews() throws DukeException {
+//
+//         //PieChart pieChart = new PieChart();
+//        Map<String, Integer> counterMap = new HashMap<>();
+//        counterMap = duke.getStorageManager().loadCommandFrequency();
+//        ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
+//        ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
+//
+//        ObservableList<javafx.scene.chart.PieChart.Data> list = FXCollections.observableArrayList(
+//
+//                new javafx.scene.chart.PieChart.Data(commandNameList.get(0) , frequencyList.get(0)),
+//                new javafx.scene.chart.PieChart.Data(commandNameList.get(1) , frequencyList.get(1))
+//        );
+//        pieChart.setData(list);
+//
+//    }
+
+    public void handlePieChartButton() throws DukeException, IOException {
+        Map<String, Integer> counterMap = new HashMap<>();
+        counterMap = duke.getStorageManager().loadCommandFrequency();
+        ArrayList<Integer> frequencyList = new ArrayList<Integer>(counterMap.values());
+        ArrayList<String> commandNameList = new ArrayList<String>(counterMap.keySet());
+        ObservableList<javafx.scene.chart.PieChart.Data> list = FXCollections.observableArrayList(
+
+                new PieChart.Data(commandNameList.get(0) , frequencyList.get(0)),
+                new PieChart.Data(commandNameList.get(1) , frequencyList.get(1))
+//                new PieChart.Data(commandNameList.get(2) , frequencyList.get(2))
+//                new PieChart.Data(commandNameList.get(3) , frequencyList.get(3)),
+//                new PieChart.Data(commandNameList.get(4) , frequencyList.get(4)),
+//                new PieChart.Data(commandNameList.get(5) , frequencyList.get(5)),
+//                new PieChart.Data(commandNameList.get(6) , frequencyList.get(6)),
+//                new PieChart.Data(commandNameList.get(7) , frequencyList.get(7)),
+//                new PieChart.Data(commandNameList.get(8) , frequencyList.get(8))
+//                new PieChart.Data(commandNameList.get(9) , frequencyList.get(9)),
+//                new PieChart.Data(commandNameList.get(10) , frequencyList.get(10)),
+//                new PieChart.Data(commandNameList.get(11) , frequencyList.get(11)),
+//                new PieChart.Data(commandNameList.get(12) , frequencyList.get(12))
+
+        );
+        pieChart.setData(list);
+    }
+
+
+
 
     private Image userImage = new Image(this.getClass().getResourceAsStream("/images/user.png"));
     private Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/robot.png"));
@@ -153,7 +227,7 @@ public class MainWindow extends AnchorPane {
     }
 
     /**
-     * Action takes to after add patient button is being pressed.
+     * Action takes to after update patient button is being pressed.
      */
     @FXML
     private void handleUpdatePatientButton() {
@@ -168,7 +242,7 @@ public class MainWindow extends AnchorPane {
     }
 
     /**
-     * Action takes to after add patient button is being pressed.
+     * Action takes to after delete patient button is being pressed.
      */
     @FXML
     private void handleDeletePatientButton() {
@@ -185,6 +259,61 @@ public class MainWindow extends AnchorPane {
     private void handleListPatientsButton() {
         executeDukeWithInput("list patients");
     }
+
+    /**
+     * Action takes to after add patient button is being pressed.
+     */
+    @FXML
+    private void handleAddTaskButton() {
+        String name = addTaskNameField.getText();
+        String input = "add task:" + name;
+        executeDukeWithInput(input);
+        addTaskNameField.clear();
+    }
+
+    /**
+     * Action takes to after add patient button is being pressed.
+     */
+    @FXML
+    private void handleDeleteTaskButton() {
+        String Id = deleteTaskIdField.getText();
+        String input = "delete task:" + "#" + Id;
+        executeDukeWithInput(input);
+        deleteTaskIdField.clear();
+    }
+
+    /**
+     * Action takes to after add patient button is being pressed.
+     */
+    @FXML
+    private void handleListTasksButton() {
+        executeDukeWithInput("list tasks");
+    }
+
+    /**
+     * Action takes to after add patient button is being pressed.
+     */
+    @FXML
+    private void handleAssignTaskButton() {
+        String taskId = assignTaskIdField.getText();
+        String patientId = assignTaskPatientIdField.getText();
+        LocalDate startDate = assignTaskStartDatePicker.getValue();
+        LocalDate endDate = assignTaskEndDatePicker.getValue();
+        String startDateInString = startDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        String endDateInString = endDate.format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
+        String startTime = assignTaskStartTimeField.getText();
+        String endTime = assignTaskEndTimeField.getText();
+        String input = "assign period task :" + "#" + patientId + " :"
+                        + "#" + taskId + " :" + startDateInString + " " + startTime
+                        + " :" + endDateInString + " " + endTime;
+        executeDukeWithInput(input);
+        assignTaskIdField.clear();
+        assignTaskPatientIdField.clear();
+        assignTaskStartTimeField.clear();
+        assignTaskEndTimeField.clear();
+    }
+
+
 
     /**
      * execute duke core with userInput command given,

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.Tab?>
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.TableColumn?>
@@ -116,50 +119,50 @@
          <children>
             <TabPane prefHeight="714.0" prefWidth="334.0" side="LEFT" tabClosingPolicy="UNAVAILABLE" AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="5.0">
               <tabs>
-                <Tab text="Patient Command">
+                <Tab text="Patient Commands">
                   <content>
                     <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="714.0" prefWidth="279.0">
                            <children>
-                              <Button fx:id="addPatientButton" layoutX="157.0" layoutY="196.0" mnemonicParsing="false" onAction="#handleAddPatientButton" prefHeight="26.0" prefWidth="108.0" text="Add Patient" AnchorPane.leftAnchor="157.0" AnchorPane.rightAnchor="12.0" />
+                              <Button fx:id="addPatientButton" layoutX="11.0" layoutY="196.0" mnemonicParsing="false" onAction="#handleAddPatientButton" prefHeight="27.0" prefWidth="257.0" text="Add Patient" AnchorPane.leftAnchor="11.0" AnchorPane.rightAnchor="5.0" />
                               <Text fontSmoothingType="LCD" layoutX="13.0" layoutY="36.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Patient command shortcuts" wrappingWidth="262.0" AnchorPane.leftAnchor="13.0" AnchorPane.topAnchor="14.41796875">
                                  <font>
                                     <Font size="20.0" />
                                  </font>
                               </Text>
-                              <TextField fx:id="addPatientNameField" layoutX="75.0" layoutY="62.0" prefHeight="25.0" prefWidth="200.0" promptText="Name" />
-                              <TextField fx:id="addPatientNricField" layoutX="78.0" layoutY="93.0" prefHeight="25.0" prefWidth="193.0" promptText="NRIC" />
-                              <TextField fx:id="addPatientRoomField" layoutX="77.0" layoutY="125.0" prefHeight="28.0" prefWidth="87.0" promptText="Room" />
-                              <TextField fx:id="addPatientRemarkField" layoutX="77.0" layoutY="159.0" prefHeight="30.0" prefWidth="187.0" promptText="Remark" />
-                              <Text layoutX="6.0" layoutY="82.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Name:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="6.0" AnchorPane.rightAnchor="216.86328125">
+                              <TextField fx:id="addPatientNameField" alignment="CENTER" layoutX="75.0" layoutY="62.0" prefHeight="27.0" prefWidth="187.0" promptText="Name" />
+                              <TextField fx:id="addPatientNricField" alignment="CENTER" layoutX="75.0" layoutY="93.0" prefHeight="27.0" prefWidth="187.0" promptText="NRIC" />
+                              <TextField fx:id="addPatientRoomField" alignment="CENTER" layoutX="76.0" layoutY="125.0" prefHeight="28.0" prefWidth="187.0" promptText="Room" />
+                              <TextField fx:id="addPatientRemarkField" alignment="CENTER" layoutX="77.0" layoutY="159.0" prefHeight="30.0" prefWidth="187.0" promptText="Remark" />
+                              <Text layoutX="13.0" layoutY="82.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Name:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="13.0" AnchorPane.rightAnchor="205.86328125">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Text layoutX="6.0" layoutY="113.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Nric:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="6.0" AnchorPane.rightAnchor="216.86328125">
+                              <Text layoutX="13.0" layoutY="115.0" strokeType="OUTSIDE" strokeWidth="0.0" text="NRIC:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="13.0" AnchorPane.rightAnchor="205.86328125">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Text layoutX="6.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Room:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="6.0" AnchorPane.rightAnchor="216.86328125">
+                              <Text layoutX="13.0" layoutY="146.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Room:" textAlignment="CENTER" wrappingWidth="54.13671875" AnchorPane.leftAnchor="13.0" AnchorPane.rightAnchor="205.86328125">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Text layoutY="181.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Remark:" textAlignment="CENTER" wrappingWidth="80.13671875" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="196.86328125">
+                              <Text layoutY="180.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Remark:" textAlignment="CENTER" wrappingWidth="80.13671875" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="192.86328125">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Button fx:id="updatePatientButton" layoutX="157.0" layoutY="358.0" mnemonicParsing="false" onAction="#handleUpdatePatientButton" prefHeight="26.0" prefWidth="108.0" text="Update Patient" />
-                              <TextField fx:id="updatePatientIdField" layoutX="101.0" layoutY="256.0" prefHeight="25.0" prefWidth="167.0" promptText="Patient id" />
-                              <TextField fx:id="updatePatientColumnField" layoutX="139.0" layoutY="291.0" prefHeight="25.0" prefWidth="129.0" promptText="eg name, nric etc" />
-                              <TextField fx:id="updatePatientContentField" layoutX="140.0" layoutY="324.0" prefHeight="28.0" prefWidth="128.0" promptText="Room" />
-                              <Text layoutX="-4.0" layoutY="275.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Patinet ID:" textAlignment="CENTER" wrappingWidth="105.13671875">
+                              <Button fx:id="updatePatientButton" layoutX="10.0" layoutY="358.0" mnemonicParsing="false" onAction="#handleUpdatePatientButton" prefHeight="27.0" prefWidth="255.0" text="Update Patient" />
+                              <TextField fx:id="updatePatientIdField" layoutX="139.0" layoutY="256.0" prefHeight="27.0" prefWidth="129.0" promptText="Patient ID" />
+                              <TextField fx:id="updatePatientColumnField" layoutX="139.0" layoutY="291.0" prefHeight="25.0" prefWidth="129.0" promptText="e.g. name, NRIC etc" />
+                              <TextField fx:id="updatePatientContentField" layoutX="140.0" layoutY="324.0" prefHeight="28.0" prefWidth="128.0" promptText="update content" />
+                              <Text layoutX="-4.0" layoutY="275.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Patient ID:" textAlignment="CENTER" wrappingWidth="105.13671875">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Text layoutX="3.0" layoutY="310.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Field to update: " textAlignment="CENTER" wrappingWidth="133.13671875">
+                              <Text layoutX="7.0" layoutY="311.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Field to update: " textAlignment="CENTER" wrappingWidth="120.13671875">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
@@ -169,18 +172,67 @@
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Button fx:id="deletePatientButton" layoutX="157.0" layoutY="462.0" mnemonicParsing="false" onAction="#handleDeletePatientButton" prefHeight="26.0" prefWidth="108.0" text="Delete Patient" />
-                              <TextField fx:id="deletePatientIdField" layoutX="140.0" layoutY="430.0" prefHeight="25.0" prefWidth="129.0" promptText="patient id" />
-                              <Text layoutX="3.0" layoutY="449.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Patient ID:" textAlignment="CENTER" wrappingWidth="133.13671875">
+                              <Button fx:id="deletePatientButton" layoutX="8.0" layoutY="449.0" mnemonicParsing="false" onAction="#handleDeletePatientButton" prefHeight="27.0" prefWidth="258.0" text="Delete Patient" />
+                              <TextField fx:id="deletePatientIdField" layoutX="121.0" layoutY="409.0" prefHeight="25.0" prefWidth="129.0" promptText="patient id" />
+                              <Text layoutX="26.0" layoutY="429.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Patient ID:" textAlignment="CENTER" wrappingWidth="81.13671875">
                                  <font>
                                     <Font size="18.0" />
                                  </font>
                               </Text>
-                              <Button fx:id="listPatientsButton" layoutX="157.0" layoutY="556.0" mnemonicParsing="false" onAction="#handleListPatientsButton" prefHeight="26.0" prefWidth="108.0" text="List Patients" />
+                              <Button fx:id="listPatientsButton" layoutX="150.0" layoutY="493.0" mnemonicParsing="false" onAction="#handleListPatientsButton" prefHeight="26.0" prefWidth="108.0" text="List Patients" />
+                              <Separator layoutX="7.0" layoutY="240.0" prefHeight="5.0" prefWidth="262.0" />
+                              <Separator layoutX="7.0" layoutY="400.0" prefHeight="2.0" prefWidth="267.0" />
+                              <Separator layoutX="7.0" layoutY="490.0" prefHeight="3.0" prefWidth="260.0" />
+                              <PieChart fx:id="pieChart" layoutX="14.0" layoutY="520.0" prefHeight="185.0" prefWidth="168.0" />
+                              <Button layoutX="100.0" layoutY="638.0" mnemonicParsing="false" onAction="#handlePieChartButton" text="Button" />
                            </children>
                         </AnchorPane>
                   </content>
                 </Tab>
+                  <Tab text="Task Commands">
+                    <content>
+                      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                           <children>
+                              <Text layoutX="24.0" layoutY="34.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task Command Shortcut" wrappingWidth="224.22900390625">
+                                 <font>
+                                    <Font size="20.0" />
+                                 </font>
+                              </Text>
+                              <Text layoutX="14.0" layoutY="75.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task Name:" />
+                              <TextField fx:id="addTaskNameField" layoutX="88.0" layoutY="57.0" promptText="Task Name" />
+                              <Button layoutX="17.0" layoutY="99.0" mnemonicParsing="false" onAction="#handleAddTaskButton" prefHeight="27.0" prefWidth="227.0" text="Add Task" />
+                              <Text layoutX="14.0" layoutY="169.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID :" />
+                              <TextField fx:id="deleteTaskIdField" layoutX="79.0" layoutY="151.0" promptText="Task ID" />
+                              <Button layoutX="19.0" layoutY="193.0" mnemonicParsing="false" onAction="#handleDeleteTaskButton" prefHeight="27.0" prefWidth="227.0" text="Delete Task" />
+                              <Button layoutX="67.0" layoutY="663.0" mnemonicParsing="false" onAction="#handleListTasksButton" prefHeight="7.0" prefWidth="107.0" text="List Tasks" />
+                              <Text layoutX="13.0" layoutY="313.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Assign to:" />
+                              <TextField fx:id="assignTaskPatientIdField" layoutX="73.0" layoutY="295.0" promptText="Patient ID" />
+                              <Text layoutX="17.0" layoutY="276.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
+                              <TextField fx:id="assignTaskIdField" layoutX="72.0" layoutY="258.0" prefHeight="27.0" prefWidth="162.0" promptText="Task ID" />
+                              <Text layoutX="15.0" layoutY="366.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Start:" />
+                              <Text layoutX="17.0" layoutY="403.0" strokeType="OUTSIDE" strokeWidth="0.0" text="End:" />
+                              <Button layoutX="20.0" layoutY="435.0" mnemonicParsing="false" onAction="#handleAssignTaskButton" prefHeight="27.0" prefWidth="228.0" text="Assign Task" />
+                              <DatePicker fx:id="assignTaskStartDatePicker" layoutX="59.0" layoutY="348.0" prefHeight="27.0" prefWidth="89.0" promptText="Date" />
+                              <DatePicker fx:id="assignTaskEndDatePicker" layoutX="59.0" layoutY="385.0" prefHeight="27.0" prefWidth="89.0" promptText="Date" />
+                              <TextField fx:id="assignTaskStartTimeField" layoutX="159.0" layoutY="348.0" prefHeight="27.0" prefWidth="82.0" promptText="Time" />
+                              <TextField fx:id="assignTaskEndTimeField" layoutX="160.0" layoutY="385.0" prefHeight="27.0" prefWidth="83.0" promptText="Time" />
+                              <Text layoutX="22.0" layoutY="516.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
+                              <TextField fx:id="assignTaskIdField1" layoutX="87.0" layoutY="498.0" prefHeight="27.0" prefWidth="162.0" promptText="Task ID" />
+                              <Text layoutX="24.0" layoutY="554.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
+                           </children>
+                        </AnchorPane>
+                    </content>
+                  </Tab>
+                  <Tab text="Statistic">
+                    <content>
+                      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                           <children>
+                              <PieChart fx:id="pieChart" layoutX="12.0" layoutY="14.0" prefHeight="227.0" prefWidth="249.0" />
+                              <Button layoutX="87.0" layoutY="251.0" mnemonicParsing="false" onAction="#handlePieChartButton" text="Show PieChart" />
+                           </children>
+                        </AnchorPane>
+                    </content>
+                  </Tab>
               </tabs>
                <effect>
                   <Reflection />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
@@ -18,7 +17,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="734.0" prefWidth="1300.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="duke.gui.MainWindow">
+<AnchorPane fx:id="rootPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="734.0" prefWidth="1300.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="duke.gui.MainWindow">
     <children>
         <TextField fx:id="userInput" layoutX="400.0" layoutY="558.0" onAction="#handleUserInput" prefHeight="41.0" prefWidth="187.0" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="63.0" />
         <Button fx:id="sendButton" layoutX="747.0" layoutY="649.0" mnemonicParsing="false" onAction="#handleUserInput" prefHeight="41.0" prefWidth="63.0" text="Send" AnchorPane.bottomAnchor="1.0" AnchorPane.rightAnchor="0.0" />
@@ -183,8 +182,6 @@
                               <Separator layoutX="7.0" layoutY="240.0" prefHeight="5.0" prefWidth="262.0" />
                               <Separator layoutX="7.0" layoutY="400.0" prefHeight="2.0" prefWidth="267.0" />
                               <Separator layoutX="7.0" layoutY="490.0" prefHeight="3.0" prefWidth="260.0" />
-                              <PieChart fx:id="pieChart" layoutX="14.0" layoutY="520.0" prefHeight="185.0" prefWidth="168.0" />
-                              <Button layoutX="100.0" layoutY="638.0" mnemonicParsing="false" onAction="#handlePieChartButton" text="Button" />
                            </children>
                         </AnchorPane>
                   </content>
@@ -204,7 +201,7 @@
                               <Text layoutX="14.0" layoutY="169.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID :" />
                               <TextField fx:id="deleteTaskIdField" layoutX="79.0" layoutY="151.0" promptText="Task ID" />
                               <Button layoutX="19.0" layoutY="193.0" mnemonicParsing="false" onAction="#handleDeleteTaskButton" prefHeight="27.0" prefWidth="227.0" text="Delete Task" />
-                              <Button layoutX="67.0" layoutY="663.0" mnemonicParsing="false" onAction="#handleListTasksButton" prefHeight="7.0" prefWidth="107.0" text="List Tasks" />
+                              <Button layoutX="61.0" layoutY="516.0" mnemonicParsing="false" onAction="#handleListTasksButton" prefHeight="68.0" prefWidth="134.0" text="List Tasks" />
                               <Text layoutX="13.0" layoutY="313.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Assign to:" />
                               <TextField fx:id="assignTaskPatientIdField" layoutX="73.0" layoutY="295.0" promptText="Patient ID" />
                               <Text layoutX="17.0" layoutY="276.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
@@ -216,9 +213,6 @@
                               <DatePicker fx:id="assignTaskEndDatePicker" layoutX="59.0" layoutY="385.0" prefHeight="27.0" prefWidth="89.0" promptText="Date" />
                               <TextField fx:id="assignTaskStartTimeField" layoutX="159.0" layoutY="348.0" prefHeight="27.0" prefWidth="82.0" promptText="Time" />
                               <TextField fx:id="assignTaskEndTimeField" layoutX="160.0" layoutY="385.0" prefHeight="27.0" prefWidth="83.0" promptText="Time" />
-                              <Text layoutX="22.0" layoutY="516.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
-                              <TextField fx:id="assignTaskIdField1" layoutX="87.0" layoutY="498.0" prefHeight="27.0" prefWidth="162.0" promptText="Task ID" />
-                              <Text layoutX="24.0" layoutY="554.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Task ID:" />
                            </children>
                         </AnchorPane>
                     </content>
@@ -227,8 +221,8 @@
                     <content>
                       <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                            <children>
-                              <PieChart fx:id="pieChart" layoutX="12.0" layoutY="14.0" prefHeight="227.0" prefWidth="249.0" />
-                              <Button layoutX="87.0" layoutY="251.0" mnemonicParsing="false" onAction="#handlePieChartButton" text="Show PieChart" />
+                              <Button layoutX="67.0" layoutY="96.0" mnemonicParsing="false" onAction="#handlePieChartPopUpButton" prefHeight="94.0" prefWidth="140.0" text="Pie Chart" />
+                              <Button layoutX="67.0" layoutY="280.0" mnemonicParsing="false" onAction="#handleBarChartPopUpButton" prefHeight="94.0" prefWidth="140.0" text="Bar Chart" />
                            </children>
                         </AnchorPane>
                     </content>


### PR DESCRIPTION
To resolve issues/stories #179 ,
I have integrated my counter implementation into our GUI to allow our user to understand their behaviour in using Dukepital. This is mainly to enable them to set up personalised short cut setting in GUI. Although this setting feature has not been implemented yet, but this most likely will be in our v2.0 features.

Here is a screenshot to show the visual look of this newly added feature:

<img width="751" alt="Screenshot 2019-10-28 at 7 39 46 PM" src="https://user-images.githubusercontent.com/47095237/67675684-b8224e00-f9ba-11e9-9ed3-1cc187e6a845.png">

In addition , since my initial "duke" command(a shortcut method based on CLI) was removed I have added various shortcut method in GUI form as shown in the screenshot below:
<img width="254" alt="Screenshot 2019-10-28 at 7 43 46 PM" src="https://user-images.githubusercontent.com/47095237/67675939-63cb9e00-f9bb-11e9-9ced-2ab2e1b008f3.png">


<img width="271" alt="Screenshot 2019-10-28 at 7 44 03 PM" src="https://user-images.githubusercontent.com/47095237/67675923-57474580-f9bb-11e9-964e-5ebab8478daa.png">


