### PR TITLE
Upcoming Tasks (CLI)

### DIFF
--- a/src/main/java/duke/commands/CommandManager.java
+++ b/src/main/java/duke/commands/CommandManager.java
@@ -19,11 +19,14 @@ import duke.commands.task.AddTaskCommand;
 import duke.commands.task.DeleteTaskCommand;
 import duke.commands.task.FindTaskCommand;
 import duke.commands.task.ListTasksCommand;
+import duke.commands.task.UpcomingTasksCommand;
 import duke.commands.task.UpdateTaskCommand;
 import duke.exceptions.DukeException;
 import duke.util.DukeUi;
 import duke.util.Parser;
 import duke.util.TypoCorrector;
+
+import java.time.LocalDateTime;
 
 /**
  * Represents a Parser that parses user input into a specific
@@ -136,6 +139,8 @@ public class CommandManager {
                 throw new DukeException("Please use the `update task :#<task id>"
                         + " :<updated description>` format.");
             }
+        case "show upcoming tasks":
+            return new UpcomingTasksCommand(LocalDateTime.now());
         case "duke":
             return new DukeCommand();
         case "bye":

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -17,6 +17,11 @@ public class UpcomingTasksCommand implements Command {
     LocalDateTime fromDate;
     ArrayList<LocalDateTime> dates = new ArrayList<LocalDateTime>();
 
+    /**
+     * The constructor for the UpcomingTasksCommand. Takes today's date and prepares UpcomingTask lists
+     * for each day within the following week.
+     * @param fromDate The current date.
+     */
     public UpcomingTasksCommand(LocalDateTime fromDate) {
         this.fromDate = fromDate;
         for (int i = 0; i < 7; i++) {
@@ -26,7 +31,9 @@ public class UpcomingTasksCommand implements Command {
     }
 
     @Override
-    public void execute(AssignedTaskManager patientTask, TaskManager tasks, PatientManager patientList, DukeUi dukeUi, StorageManager storageManager) throws DukeException {
+    public void execute(AssignedTaskManager patientTask, TaskManager tasks,
+                        PatientManager patientList, DukeUi dukeUi,
+                        StorageManager storageManager) throws DukeException {
         for (LocalDateTime date : dates) {
             UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask, tasks, patientList);
             dukeUi.showUpcomingTasks(upcomingTaskForDay);

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -28,9 +28,8 @@ public class UpcomingTasksCommand implements Command {
     @Override
     public void execute(AssignedTaskManager patientTask, TaskManager tasks, PatientManager patientList, DukeUi dukeUi, StorageManager storageManager) throws DukeException {
         for (LocalDateTime date : dates) {
-            UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask, tasks);
-            dukeUi.showUpcomingTasks(upcomingTaskForDay.getFormattedDate(),
-                    upcomingTaskForDay.getUpcomingTaskDescriptions(), upcomingTaskForDay.getUpcomingTasks());
+            UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask, tasks, patientList);
+            dukeUi.showUpcomingTasks(upcomingTaskForDay);
         }
 
     }

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -1,3 +1,5 @@
+//@@lmtaek
+
 package duke.commands.task;
 
 import duke.commands.Command;

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -1,0 +1,44 @@
+package duke.commands.task;
+
+import duke.commands.Command;
+import duke.exceptions.DukeException;
+import duke.models.assignedtasks.AssignedTaskManager;
+import duke.models.assignedtasks.UpcomingTasks;
+import duke.models.patients.PatientManager;
+import duke.models.tasks.TaskManager;
+import duke.storages.StorageManager;
+import duke.util.DukeUi;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+public class UpcomingTasksCommand implements Command {
+
+    LocalDateTime fromDate;
+    ArrayList<LocalDateTime> dates = new ArrayList<LocalDateTime>();
+
+    public UpcomingTasksCommand(LocalDateTime fromDate) {
+        this.fromDate = fromDate;
+        for (int i = 0; i < 7; i++) {
+            LocalDateTime currentDate = fromDate.plusDays(i);
+            dates.add(currentDate);
+        }
+    }
+
+    @Override
+    public void execute(AssignedTaskManager patientTask, TaskManager tasks, PatientManager patientList, DukeUi dukeUi, StorageManager storageManager) throws DukeException {
+        for (LocalDateTime date : dates) {
+            UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask);
+            dukeUi.showUpcomingTasks(upcomingTaskForDay.getFormattedDate(),
+                    upcomingTaskForDay.getUpcomingTasks());
+        }
+
+    }
+
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+
+
+}

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -28,9 +28,9 @@ public class UpcomingTasksCommand implements Command {
     @Override
     public void execute(AssignedTaskManager patientTask, TaskManager tasks, PatientManager patientList, DukeUi dukeUi, StorageManager storageManager) throws DukeException {
         for (LocalDateTime date : dates) {
-            UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask);
+            UpcomingTasks upcomingTaskForDay = new UpcomingTasks(date, patientTask, tasks);
             dukeUi.showUpcomingTasks(upcomingTaskForDay.getFormattedDate(),
-                    upcomingTaskForDay.getUpcomingTasks());
+                    upcomingTaskForDay.getUpcomingTaskDescriptions(), upcomingTaskForDay.getUpcomingTasks());
         }
 
     }

--- a/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
+++ b/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
@@ -1,6 +1,9 @@
+//@@lmtaek
+
 package duke.models.assignedtasks;
 
 import duke.exceptions.DukeException;
+import duke.models.patients.PatientManager;
 import duke.models.tasks.TaskManager;
 
 import java.time.LocalDate;
@@ -14,9 +17,10 @@ public class UpcomingTasks {
     LocalDate date;
     ArrayList<AssignedTask> tasks = new ArrayList<AssignedTask>();
     ArrayList<String> taskDescriptions = new ArrayList<String>();
+    ArrayList<String> patientsForTasks = new ArrayList<String>();
     DateTimeFormatter dateFormatParser = DateTimeFormatter.ofPattern("E, dd/MM");
 
-    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager, TaskManager taskManager) throws DukeException {
+    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager, TaskManager taskManager, PatientManager patientManager) throws DukeException {
         this.dateTime = dateTime;
         this.date = dateTime.toLocalDate();
         for (AssignedTask task : assignedTaskManager.getAssignTasks()) {
@@ -48,6 +52,10 @@ public class UpcomingTasks {
         for (AssignedTask task : tasks) {
             taskDescriptions.add(taskManager.getTask(task.getTid()).getDescription());
         }
+
+        for (AssignedTask task : tasks) {
+            patientsForTasks.add(patientManager.getPatient(task.getPid()).getName());
+        }
     }
 
     public ArrayList<AssignedTask> getUpcomingTasks() {
@@ -56,6 +64,10 @@ public class UpcomingTasks {
 
     public ArrayList<String> getUpcomingTaskDescriptions() {
         return taskDescriptions;
+    }
+
+    public ArrayList<String> getPatientNames() {
+        return patientsForTasks;
     }
 
     public String getFormattedDate() {

--- a/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
+++ b/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
@@ -1,6 +1,7 @@
 package duke.models.assignedtasks;
 
 import duke.exceptions.DukeException;
+import duke.models.tasks.TaskManager;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,9 +13,10 @@ public class UpcomingTasks {
     LocalDateTime dateTime;
     LocalDate date;
     ArrayList<AssignedTask> tasks = new ArrayList<AssignedTask>();
+    ArrayList<String> taskDescriptions = new ArrayList<String>();
     DateTimeFormatter dateFormatParser = DateTimeFormatter.ofPattern("E, dd/MM");
 
-    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager) throws DukeException {
+    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager, TaskManager taskManager) throws DukeException {
         this.dateTime = dateTime;
         this.date = dateTime.toLocalDate();
         for (AssignedTask task : assignedTaskManager.getAssignTasks()) {
@@ -42,10 +44,18 @@ public class UpcomingTasks {
                 + getFormattedDate() + ".");
             }
         }
+
+        for (AssignedTask task : tasks) {
+            taskDescriptions.add(taskManager.getTask(task.getTid()).getDescription());
+        }
     }
 
     public ArrayList<AssignedTask> getUpcomingTasks() {
         return tasks;
+    }
+
+    public ArrayList<String> getUpcomingTaskDescriptions() {
+        return taskDescriptions;
     }
 
     public String getFormattedDate() {

--- a/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
+++ b/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
@@ -20,7 +20,18 @@ public class UpcomingTasks {
     ArrayList<String> patientsForTasks = new ArrayList<String>();
     DateTimeFormatter dateFormatParser = DateTimeFormatter.ofPattern("E, dd/MM");
 
-    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager, TaskManager taskManager, PatientManager patientManager) throws DukeException {
+    /**
+     * Constructor for Upcoming Tasks class. Will create task list for tasks assigned to provided date,
+     * and find relevant corresponding information to be provided to the user such as task descriptions,
+     * or patients involved in tasks.
+     * @param dateTime The provided date for the desired upcoming tasks.
+     * @param assignedTaskManager The user's list of assigned tasks.
+     * @param taskManager The user's list of all tasks.
+     * @param patientManager The user's list of all patient profiles.
+     * @throws DukeException Thrown when the constructor is unable to find all the required information.
+     */
+    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager,
+                         TaskManager taskManager, PatientManager patientManager) throws DukeException {
         this.dateTime = dateTime;
         this.date = dateTime.toLocalDate();
         for (AssignedTask task : assignedTaskManager.getAssignTasks()) {
@@ -45,7 +56,7 @@ public class UpcomingTasks {
                 }
             } else {
                 throw new DukeException("Unable to determine upcoming tasks for "
-                + getFormattedDate() + ".");
+                        + getFormattedDate() + ".");
             }
         }
 
@@ -58,18 +69,34 @@ public class UpcomingTasks {
         }
     }
 
+    /**
+     * Returns AssignedTask array list with all tasks designated for the provided date.
+     * @return Array list with designated date's tasks
+     */
     public ArrayList<AssignedTask> getUpcomingTasks() {
         return tasks;
     }
 
+    /**
+     * Returns String array list with all descriptions of designated tasks for provided date.
+     * @return Array list with task descriptions for designated date's tasks
+     */
     public ArrayList<String> getUpcomingTaskDescriptions() {
         return taskDescriptions;
     }
 
+    /**
+     * Returns String array list with all patient names of designated tasks for provided date.
+     * @return Array list with patient names for designated date's tasks
+     */
     public ArrayList<String> getPatientNames() {
         return patientsForTasks;
     }
 
+    /**
+     * Returns String version of provided date in 'E, dd/MM' format.
+     * @return Reformatted date.
+     */
     public String getFormattedDate() {
         return dateTime.format(dateFormatParser);
     }

--- a/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
+++ b/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
@@ -1,0 +1,55 @@
+package duke.models.assignedtasks;
+
+import duke.exceptions.DukeException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+
+public class UpcomingTasks {
+
+    LocalDateTime dateTime;
+    LocalDate date;
+    ArrayList<AssignedTask> tasks = new ArrayList<AssignedTask>();
+    DateTimeFormatter dateFormatParser = DateTimeFormatter.ofPattern("E, dd/MM");
+
+    public UpcomingTasks(LocalDateTime dateTime, AssignedTaskManager assignedTaskManager) throws DukeException {
+        this.dateTime = dateTime;
+        this.date = dateTime.toLocalDate();
+        for (AssignedTask task : assignedTaskManager.getAssignTasks()) {
+            if (task.getTodoDate() != null) {
+                LocalDateTime taskTime = task.getTodoDate();
+                LocalDate taskDate = task.getTodoDate().toLocalDate();
+
+                if (taskTime.isAfter(dateTime) && taskDate.isBefore(date.plusDays(1))) {
+                    tasks.add(task);
+                }
+            } else if (task.getStartDate() != null && task.getEndDate() != null) {
+                LocalDateTime startTime = task.getStartDate();
+                LocalDate startDate = task.getStartDate().toLocalDate();
+                LocalDateTime endTime = task.getEndDate();
+                LocalDate endDate = task.getEndDate().toLocalDate();
+
+                if ((startTime.isAfter(dateTime)
+                        && startDate.isBefore(date.plusDays(1)))
+                        || (endTime.isAfter(dateTime)
+                        && endDate.isBefore(date.plusDays(1)))) {
+                    tasks.add(task);
+                }
+            } else {
+                throw new DukeException("Unable to determine upcoming tasks for "
+                + getFormattedDate() + ".");
+            }
+        }
+    }
+
+    public ArrayList<AssignedTask> getUpcomingTasks() {
+        return tasks;
+    }
+
+    public String getFormattedDate() {
+        return dateTime.format(dateFormatParser);
+    }
+
+}

--- a/src/main/java/duke/util/DukeUi.java
+++ b/src/main/java/duke/util/DukeUi.java
@@ -635,6 +635,14 @@ public class DukeUi {
         }
         printDukeResponse(output);
     }
+
+    public void showUpcomingTasks(String date, ArrayList<AssignedTask> tasks) {
+        System.out.println(date + ":\n");
+        for (AssignedTask task : tasks) {
+            System.out.println(task.toString() + "\n");
+        }
+
+    }
     //@@author
 
 }

--- a/src/main/java/duke/util/DukeUi.java
+++ b/src/main/java/duke/util/DukeUi.java
@@ -636,11 +636,12 @@ public class DukeUi {
         printDukeResponse(output);
     }
 
-    public void showUpcomingTasks(String date, ArrayList<AssignedTask> tasks) {
+    public void showUpcomingTasks(String date, ArrayList<String> taskDescriptions, ArrayList<AssignedTask> tasks) {
         String output = "";
         output += date + ":\n";
-        for (AssignedTask task : tasks) {
-            output += task.toString() + "\n";
+        for (int i = 0; i < tasks.size(); i++) {
+            output += "Unique ID: " + tasks.get(i).getUuid() + ".\nDescription: "
+                    + taskDescriptions.get(i) + "\n\n";
         }
         printDukeResponse(output);
 

--- a/src/main/java/duke/util/DukeUi.java
+++ b/src/main/java/duke/util/DukeUi.java
@@ -637,10 +637,12 @@ public class DukeUi {
     }
 
     public void showUpcomingTasks(String date, ArrayList<AssignedTask> tasks) {
-        System.out.println(date + ":\n");
+        String output = "";
+        output += date + ":\n";
         for (AssignedTask task : tasks) {
-            System.out.println(task.toString() + "\n");
+            output += task.toString() + "\n";
         }
+        printDukeResponse(output);
 
     }
     //@@author

--- a/src/main/java/duke/util/DukeUi.java
+++ b/src/main/java/duke/util/DukeUi.java
@@ -637,6 +637,11 @@ public class DukeUi {
         printDukeResponse(output);
     }
 
+    /**
+     * Prints out lists for each day of upcoming week + the tasks designated for those days.
+     *
+     * @param upcomingTasks The list of tasks for the upcoming date.
+     */
     public void showUpcomingTasks(UpcomingTasks upcomingTasks) {
         String output = "";
         output += upcomingTasks.getFormattedDate() + ":\n";

--- a/src/main/java/duke/util/DukeUi.java
+++ b/src/main/java/duke/util/DukeUi.java
@@ -2,6 +2,7 @@ package duke.util;
 
 import duke.exceptions.DukeException;
 import duke.models.assignedtasks.AssignedTask;
+import duke.models.assignedtasks.UpcomingTasks;
 import duke.models.patients.Patient;
 import duke.models.tasks.Task;
 
@@ -636,12 +637,14 @@ public class DukeUi {
         printDukeResponse(output);
     }
 
-    public void showUpcomingTasks(String date, ArrayList<String> taskDescriptions, ArrayList<AssignedTask> tasks) {
+    public void showUpcomingTasks(UpcomingTasks upcomingTasks) {
         String output = "";
-        output += date + ":\n";
-        for (int i = 0; i < tasks.size(); i++) {
-            output += "Unique ID: " + tasks.get(i).getUuid() + ".\nDescription: "
-                    + taskDescriptions.get(i) + "\n\n";
+        output += upcomingTasks.getFormattedDate() + ":\n";
+        ArrayList<String> taskDescriptions = upcomingTasks.getUpcomingTaskDescriptions();
+        ArrayList<String> patientNames = upcomingTasks.getPatientNames();
+        for (int i = 0; i < upcomingTasks.getUpcomingTasks().size(); i++) {
+            output += "Unique ID: " + upcomingTasks.getUpcomingTasks().get(i).getUuid() + ".\nDescription: "
+                    + taskDescriptions.get(i) + "\nFor patient: " + patientNames.get(i) + "\n\n";
         }
         printDukeResponse(output);
 


### PR DESCRIPTION
Implementation of 'Upcoming Tasks' feature which will provide tasks with descriptions and associated patients' names for the upcoming week. 

Currently can be called with the `show upcoming tasks` command in the Command textField, but will implement GUI-friendly manner of accessing the information in later PRs. 

Associated with Issue #188 .