### PR TITLE
Fixing typo within authorship indicator for RepoSense.

### DIFF
--- a/src/main/java/duke/commands/CommandManager.java
+++ b/src/main/java/duke/commands/CommandManager.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.commands;
 

--- a/src/main/java/duke/commands/functional/HelpCommand.java
+++ b/src/main/java/duke/commands/functional/HelpCommand.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.commands.functional;
 

--- a/src/main/java/duke/commands/task/UpcomingTasksCommand.java
+++ b/src/main/java/duke/commands/task/UpcomingTasksCommand.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.commands.task;
 

--- a/src/main/java/duke/gui/HelpBox.java
+++ b/src/main/java/duke/gui/HelpBox.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.gui;
 

--- a/src/main/java/duke/gui/MainWindow.java
+++ b/src/main/java/duke/gui/MainWindow.java
@@ -561,11 +561,14 @@ public class MainWindow extends UiPart<Stage> {
         assignedTaskSearchBarListener();
         taskSearchBarListener();
 
+        //@@author lmtaek
         try {
             showUpcomingTasks();
         } catch (Exception e) {
             throw new DukeException("Failed to update Upcoming Tasks tab.");
         }
+        
+        //@@author
     }
 
     private void patientSearchBarListener() {
@@ -680,7 +683,7 @@ public class MainWindow extends UiPart<Stage> {
         assignedTaskTable.setItems(sortedAssignedTaskData);
     }
 
-    //@@lmtaek
+    //@@author lmtaek
 
     /**
      * Handler for HelpGuide tab.

--- a/src/main/java/duke/gui/UpcomingTasksBox.java
+++ b/src/main/java/duke/gui/UpcomingTasksBox.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.gui;
 

--- a/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
+++ b/src/main/java/duke/models/assignedtasks/UpcomingTasks.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.models.assignedtasks;
 

--- a/src/main/java/duke/util/Parser.java
+++ b/src/main/java/duke/util/Parser.java
@@ -1,4 +1,4 @@
-//@@lmtaek
+//@@author lmtaek
 
 package duke.util;
 


### PR DESCRIPTION
Just doing quick alterations so that contributions will be counted within the code via RepoSense. It shouldn't have any effect on the functionality of the program.