### PR TITLE
Fixed the bug which user cant undo the updatePatient and Task Command

### DIFF
--- a/src/main/java/duke/commands/patient/UpdatePatientCommand.java
+++ b/src/main/java/duke/commands/patient/UpdatePatientCommand.java
@@ -58,7 +58,15 @@ public class UpdatePatientCommand implements Command {
                 } catch (Exception e) {
                     throw e;
                 }
-                patientToBeUpdated.setName(command[2]);
+                try {
+                    Patient newPatient = new Patient(id, command[2],
+                            patientToBeUpdated.getNric(), patientToBeUpdated.getRoom(),
+                            patientToBeUpdated.getRemark());
+                    patientManager.deletePatient(id);
+                    patientManager.addPatient(newPatient);
+                } catch (Exception e) {
+                    throw e;
+                }
             } else if (command[1].toLowerCase().equals("nric")) {
                 try {
                     if (command.length == 2) {
@@ -69,7 +77,15 @@ public class UpdatePatientCommand implements Command {
                 } catch (Exception e) {
                     throw e;
                 }
-                patientToBeUpdated.setNric(command[2]);
+                try {
+                    Patient newPatient = new Patient(id, patientToBeUpdated.getName(),
+                            command[2], patientToBeUpdated.getRoom(),
+                            patientToBeUpdated.getRemark());
+                    patientManager.deletePatient(id);
+                    patientManager.addPatient(newPatient);
+                } catch (Exception e) {
+                    throw e;
+                }
             } else if (command[1].toLowerCase().equals("room")) {
                 try {
                     if (command.length == 2) {
@@ -80,12 +96,28 @@ public class UpdatePatientCommand implements Command {
                 } catch (Exception e) {
                     throw e;
                 }
-                patientToBeUpdated.setRoom(command[2]);
+                try {
+                    Patient newPatient = new Patient(id, patientToBeUpdated.getName(),
+                            patientToBeUpdated.getNric(), command[2],
+                            patientToBeUpdated.getRemark());
+                    patientManager.deletePatient(id);
+                    patientManager.addPatient(newPatient);
+                } catch (Exception e) {
+                    throw e;
+                }
             } else if (command[1].toLowerCase().equals("remark")) {
                 if (command.length == 2) {
                     patientToBeUpdated.setRemark("");
                 } else {
-                    patientToBeUpdated.setRemark(command[2]);
+                    try {
+                        Patient newPatient = new Patient(id, patientToBeUpdated.getName(),
+                                patientToBeUpdated.getNric(), patientToBeUpdated.getRoom(),
+                                command[2]);
+                        patientManager.deletePatient(id);
+                        patientManager.addPatient(newPatient);
+                    } catch (Exception e) {
+                        throw e;
+                    }
                 }
             } else {
                 throw new DukeException(UpdatePatientCommand.class,
@@ -97,7 +129,7 @@ public class UpdatePatientCommand implements Command {
                 throw e;
             }
             dukeUi.showUpdatedSuccessfully();
-            dukeUi.showPatientInfo(patientToBeUpdated);
+            dukeUi.showPatientInfo(patientManager.getPatient(id));
         } else {
             throw new DukeException(UpdatePatientCommand.class,
                     "Please follow the format 'update patient :#<id> :<Name/NRIC/Room/Remark> :<new information>'.");

--- a/src/main/java/duke/commands/task/UpdateTaskCommand.java
+++ b/src/main/java/duke/commands/task/UpdateTaskCommand.java
@@ -43,14 +43,16 @@ public class UpdateTaskCommand implements Command {
                 id = Integer.parseInt(command[0].substring(1));
                 Task taskToBeUpdated = taskManager.getTask(id);
                 if (command[1].toLowerCase().equals("description")) {
-                    taskToBeUpdated.setDescription(command[2]);
+                    Task newTask = new Task(id, command[2]);
+                    taskManager.deleteTask(id);
+                    taskManager.addTask(newTask);
                 } else {
                     throw new DukeException(UpdateTaskCommand.class, "You can only update 'Description' of the task");
                 }
 
                 storageManager.saveTasks(taskManager.getTaskList());
                 dukeUi.showUpdatedSuccessfully();
-                dukeUi.showTaskInfo(taskToBeUpdated);
+                dukeUi.showTaskInfo(taskManager.getTask(id));
             } catch (Exception e) {
                 throw e;
             }


### PR DESCRIPTION
Fixed the bug which update task and patient command will not be saved into the memento pattern correctly, causing a problem to undo these 2 commands.

This is really an interesting bug. Even when i'm trying to save our internal state of the objects before any command that will modify the internal state was executed by creating a  new object of our PatientManager and TaskManager with a new ArrayList returned with same value (Clone the objects, instead of pass the reference address). Kejun's UpdateTaskCommand and UpdatePatientCommand will get the specific task or patient and call their internal methods such as setName();...etc to modify the task or patient's internal state. And yes! the internal method calls will still be able to modified the new ArrayList i generated from PatientManager and TaskManger......Jesus.

So the solution is simple.. instead of calling the internal methods of these task or patients to update them, i will just create a new task or patient object with the updated information, and delete the original one, in such way, the problem has been successfully solved.
(I guess this is why in SQL, when we trying to update a row from a table, it will not modify the data, instead it will create two temporary table Inserted and deleted to insert a new row with updated information and remove the old one )
